### PR TITLE
Merge Dev into Master

### DIFF
--- a/Spacearr.Android/MainActivity.cs
+++ b/Spacearr.Android/MainActivity.cs
@@ -3,11 +3,13 @@ using Android.Content;
 using Android.Content.PM;
 using Android.OS;
 using Android.Runtime;
+using Android.Views;
 using AndroidX.Work;
 using Java.Util.Concurrent;
 using Spacearr.Core.Xamarin.Notifications;
 using Spacearr.Droid.Notifications;
 using Xamarin.Forms;
+using Xamarin.Forms.Platform.Android;
 
 namespace Spacearr.Droid
 {
@@ -32,6 +34,15 @@ namespace Spacearr.Droid
             builder.SetConstraints(Constraints.None);
             var workRequest = builder.Build();
             WorkManager.Instance.EnqueueUniquePeriodicWork(taskId, ExistingPeriodicWorkPolicy.Keep, workRequest);
+
+            if (Build.VERSION.SdkInt >= BuildVersionCodes.Lollipop)
+            {
+                var themeDarkColor = (Color)Xamarin.Forms.Application.Current.Resources["ThemeDarkColor"];
+
+                Window.ClearFlags(WindowManagerFlags.TranslucentStatus);
+                Window.AddFlags(WindowManagerFlags.DrawsSystemBarBackgrounds);
+                Window.SetStatusBarColor(themeDarkColor.ToAndroid());
+            }
         }
 
         public override void OnRequestPermissionsResult(int requestCode, string[] permissions, [GeneratedEnum] Android.Content.PM.Permission[] grantResults)

--- a/Spacearr.Core.Xamarin/App.xaml
+++ b/Spacearr.Core.Xamarin/App.xaml
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Application xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
              mc:Ignorable="d"
              x:Class="Spacearr.Core.Xamarin.App">
 </Application>

--- a/Spacearr.Core.Xamarin/Controls/FloatingEntry.xaml
+++ b/Spacearr.Core.Xamarin/Controls/FloatingEntry.xaml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentView xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             mc:Ignorable="d"
+             x:Class="Spacearr.Core.Xamarin.Controls.FloatingEntry">
+
+    <ContentView.Content>
+        <Grid BackgroundColor="{DynamicResource ThemeBackgroundColor}">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+            <Label x:Name="HiddenLabel" d:Text="Hidden Label" FontSize="10" IsVisible="False" Margin="0,15,0,10"/>
+            <Entry Grid.Row="0" x:Name="EntryField" d:Text="Entry Field" Text="{Binding Text, Mode=TwoWay}" Margin="0,12,0,0"/>
+        </Grid>
+    </ContentView.Content>
+
+</ContentView>

--- a/Spacearr.Core.Xamarin/Controls/FloatingEntry.xaml.cs
+++ b/Spacearr.Core.Xamarin/Controls/FloatingEntry.xaml.cs
@@ -1,0 +1,102 @@
+﻿using System.ComponentModel;
+using System.Threading.Tasks;
+using Xamarin.Forms;
+
+namespace Spacearr.Core.Xamarin.Controls
+{
+    [DesignTimeVisible(false)]
+    public partial class FloatingEntry : ContentView
+    {
+        public static BindableProperty TextProperty = BindableProperty.Create(nameof(Text), typeof(string), typeof(FloatingEntry), defaultBindingMode: BindingMode.TwoWay, propertyChanged: (bindable, oldVal, newValue) => {
+            var floatingEntry = (FloatingEntry)bindable;
+
+            if (!string.IsNullOrWhiteSpace((string)newValue))
+            {
+                floatingEntry.HiddenLabel.IsVisible = true;
+                floatingEntry.HiddenLabel.TranslationY = -21;
+                floatingEntry.EntryField.Placeholder = null;
+            }
+        });
+        public static BindableProperty PlaceholderProperty = BindableProperty.Create(nameof(Placeholder), typeof(string), typeof(FloatingEntry), defaultBindingMode: BindingMode.TwoWay, propertyChanged: (bindable, oldVal, newValue) => {
+            var floatingEntry = (FloatingEntry)bindable;
+            floatingEntry.EntryField.Placeholder = (string)newValue;
+            floatingEntry.HiddenLabel.Text = (string)newValue;
+        });
+        public static BindableProperty IsPasswordProperty = BindableProperty.Create(nameof(IsPassword), typeof(bool), typeof(FloatingEntry), false, propertyChanged: (bindable, oldVal, newVal) => {
+            var floatingEntry = (FloatingEntry)bindable;
+            floatingEntry.EntryField.IsPassword = (bool)newVal;
+        });
+        public static BindableProperty KeyboardProperty = BindableProperty.Create(nameof(Keyboard), typeof(Keyboard), typeof(FloatingEntry), Keyboard.Default, propertyChanged: (bindable, oldVal, newVal) => {
+            var floatingEntry = (FloatingEntry)bindable;
+            floatingEntry.EntryField.Keyboard = (Keyboard)newVal;
+        });
+        public static BindableProperty TextColorProperty = BindableProperty.Create(nameof(TextColor), typeof(Color), typeof(FloatingEntry), Color.Accent);
+        public static BindableProperty EntryPlaceholderColorProperty = BindableProperty.Create(nameof(EntryPlaceholderColor), typeof(Color), typeof(FloatingEntry), Color.Accent);
+        public static BindableProperty EntryBackgroundColorProperty = BindableProperty.Create(nameof(EntryBackgroundColor), typeof(Color), typeof(FloatingEntry), Color.Accent);
+        public Color TextColor
+        {
+            get => (Color)GetValue(TextColorProperty);
+            set => SetValue(TextColorProperty, value);
+        }
+        public Color EntryPlaceholderColor
+        {
+            get => (Color)GetValue(EntryPlaceholderColorProperty);
+            set => SetValue(EntryPlaceholderColorProperty, value);
+        }
+        public Color EntryBackgroundColor
+        {
+            get => (Color)GetValue(EntryBackgroundColorProperty);
+            set => SetValue(EntryBackgroundColorProperty, value);
+        }
+        public Keyboard Keyboard
+        {
+            get => (Keyboard)GetValue(KeyboardProperty);
+            set => SetValue(KeyboardProperty, value);
+        }
+        public bool IsPassword
+        {
+            get => (bool)GetValue(IsPasswordProperty);
+            set => SetValue(IsPasswordProperty, value);
+        }
+        public string Text
+        {
+            get => (string)GetValue(TextProperty);
+            set => SetValue(TextProperty, value);
+        }
+        public string Placeholder
+        {
+            get => (string)GetValue(PlaceholderProperty);
+            set => SetValue(PlaceholderProperty, value);
+        }
+
+        public FloatingEntry()
+        {
+            InitializeComponent();
+            EntryField.BindingContext = this;
+
+            EntryField.TextColor = TextColor;
+            EntryField.PlaceholderColor = EntryPlaceholderColor;
+            EntryField.BackgroundColor = EntryBackgroundColor;
+            HiddenLabel.TextColor = TextColor;
+
+            EntryField.Focused += async (s, a) =>
+            {
+                HiddenLabel.IsVisible = true;
+                if (string.IsNullOrEmpty(EntryField.Text))
+                {
+                    HiddenLabel.Margin = new Thickness(0, 15, 0, 10);
+                    await Task.WhenAll(HiddenLabel.FadeTo(1, 120), HiddenLabel.TranslateTo(HiddenLabel.TranslationX, EntryField.Y - EntryField.Height, 200, Easing.BounceIn));
+                    EntryField.Placeholder = null;
+                }
+            };
+            EntryField.Unfocused += async (s, a) => 
+            {
+                if (string.IsNullOrEmpty(EntryField.Text))
+                {
+                    await Task.WhenAll(HiddenLabel.FadeTo(0, 180), HiddenLabel.TranslateTo(HiddenLabel.TranslationX, EntryField.Y, 50, Easing.BounceIn));
+                    EntryField.Placeholder = Placeholder;
+                }
+            };
+        }
+    }
+}

--- a/Spacearr.Core.Xamarin/Controls/FloatingLabel.xaml
+++ b/Spacearr.Core.Xamarin/Controls/FloatingLabel.xaml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentView xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             mc:Ignorable="d"
+             x:Class="Spacearr.Core.Xamarin.Controls.FloatingLabel">
+
+    <ContentView.Content>
+        <Grid BackgroundColor="{DynamicResource ThemeLightColor}">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+            <Label x:Name="LabelTop" d:Text="Top Label" FontSize="10" Margin="0,15,0,10"/>
+            <Label Grid.Row="0" x:Name="LabelBottom" d:Text="Bottom Label"  Margin="0,12,0,0"/>
+        </Grid>
+    </ContentView.Content>
+
+</ContentView>

--- a/Spacearr.Core.Xamarin/Controls/FloatingLabel.xaml.cs
+++ b/Spacearr.Core.Xamarin/Controls/FloatingLabel.xaml.cs
@@ -1,0 +1,56 @@
+﻿using System.ComponentModel;
+using Xamarin.Forms;
+
+namespace Spacearr.Core.Xamarin.Controls
+{
+    [DesignTimeVisible(false)]
+    public partial class FloatingLabel : ContentView
+    {
+        public static BindableProperty LabelBottomTextProperty = BindableProperty.Create(nameof(LabelBottomText), typeof(string), typeof(FloatingLabel), defaultBindingMode: BindingMode.TwoWay, propertyChanged: (bindable, oldVal, newValue) => {
+            var floatingLabel = (FloatingLabel)bindable;
+            floatingLabel.LabelBottom.Text = (string)newValue;
+
+            if (!string.IsNullOrWhiteSpace((string)newValue))
+            {
+                floatingLabel.LabelTop.TranslationY = -18;
+            }
+        });
+        public static BindableProperty LabelTopTextProperty = BindableProperty.Create(nameof(LabelTopText), typeof(string), typeof(FloatingLabel), defaultBindingMode: BindingMode.TwoWay, propertyChanged: (bindable, oldVal, newValue) => {
+            var floatingLabel = (FloatingLabel)bindable;
+            floatingLabel.LabelTop.Text = (string)newValue;
+        });
+        public static BindableProperty TextColorProperty = BindableProperty.Create(nameof(TextColor), typeof(Color), typeof(FloatingLabel), Color.Accent);
+        public static BindableProperty LabelBackgroundColorProperty = BindableProperty.Create(nameof(LabelBackgroundColor), typeof(Color), typeof(FloatingLabel), Color.Accent);
+        public Color TextColor
+        {
+            get => (Color)GetValue(TextColorProperty);
+            set => SetValue(TextColorProperty, value);
+        }
+        public Color LabelBackgroundColor
+        {
+            get => (Color)GetValue(LabelBackgroundColorProperty);
+            set => SetValue(LabelBackgroundColorProperty, value);
+        }
+        public string LabelBottomText
+        {
+            get => (string)GetValue(LabelBottomTextProperty);
+            set => SetValue(LabelBottomTextProperty, value);
+        }
+        public string LabelTopText
+        {
+            get => (string)GetValue(LabelTopTextProperty);
+            set => SetValue(LabelTopTextProperty, value);
+        }
+
+        public FloatingLabel()
+        {
+            InitializeComponent();
+            LabelBottom.BindingContext = this;
+
+            LabelTop.TextColor = TextColor;
+            LabelBottom.TextColor = TextColor;
+            LabelTop.BackgroundColor = LabelBackgroundColor;
+            LabelBottom.BackgroundColor = LabelBackgroundColor;
+        }
+    }
+}

--- a/Spacearr.Core.Xamarin/Spacearr.Core.Xamarin.csproj
+++ b/Spacearr.Core.Xamarin/Spacearr.Core.Xamarin.csproj
@@ -29,6 +29,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Update="Controls\FloatingLabel.xaml.cs">
+      <DependentUpon>FloatingLabel.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="Controls\FloatingEntry.xaml.cs">
+      <DependentUpon>FloatingEntry.xaml</DependentUpon>
+    </Compile>
     <Compile Update="Views\ComputerDriveDetailPage.xaml.cs">
       <DependentUpon>ComputerDriveDetailPage.xaml</DependentUpon>
     </Compile>

--- a/Spacearr.Core.Xamarin/Themes/DarkTheme.xaml
+++ b/Spacearr.Core.Xamarin/Themes/DarkTheme.xaml
@@ -1,27 +1,54 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <ResourceDictionary xmlns="http://xamarin.com/schemas/2014/forms"
                     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                    xmlns:controls="clr-namespace:Spacearr.Core.Xamarin.Controls;assembly=Spacearr.Core.Xamarin"
                     x:Class="Spacearr.Core.Xamarin.Themes.DarkTheme">
 
-    <Color x:Key="ThemeColor">Black</Color>
-    <Color x:Key="ThemeTextColor">White</Color>
+    <Color x:Key="ThemeLightColor">#383838</Color>
+    <Color x:Key="ThemeNormalColor">#121212</Color>
+    <Color x:Key="ThemeDarkColor">#000000</Color>
+    <Color x:Key="ThemeTextColor">#ffffff</Color>
+    <Color x:Key="ThemeBackgroundColor">#121212</Color>
+    <Color x:Key="ThemeSwitchLightColor">#ff833a</Color>
+    <Color x:Key="ThemeSwitchNormalColor">#e65100</Color>
+    <Color x:Key="ErrorTextColor">#b71c1c</Color>
+    <Color x:Key="MicroChartsFreeSpaceColor">#ffffff</Color>
+    <Color x:Key="MicroChartsUsedSpaceColor">#ff833a</Color>
+    <Color x:Key="ProgressBarColor">#ff833a</Color>
     <Style TargetType="ContentPage">
-        <Setter Property="BackgroundColor" Value="{StaticResource ThemeColor}" />
+        <Setter Property="BackgroundColor" Value="{StaticResource ThemeDarkColor}" />
     </Style>
     <Style TargetType="NavigationPage">
-        <Setter Property="BarBackgroundColor" Value="{StaticResource ThemeColor}" />
+        <Setter Property="BarBackgroundColor" Value="{StaticResource ThemeDarkColor}" />
         <Setter Property="BarTextColor" Value="{StaticResource ThemeTextColor}" />
     </Style>
     <Style TargetType="StackLayout">
-        <Setter Property="BackgroundColor" Value="{StaticResource ThemeColor}" />
+        <Setter Property="BackgroundColor" Value="{StaticResource ThemeBackgroundColor}" />
+    </Style>
+    <Style TargetType="ListView">
+        <Setter Property="BackgroundColor" Value="{StaticResource ThemeBackgroundColor}" />
+    </Style>
+    <Style TargetType="Frame">
+        <Setter Property="BackgroundColor" Value="{StaticResource ThemeLightColor}" />
     </Style>
     <Style TargetType="Grid">
-        <Setter Property="BackgroundColor" Value="{StaticResource ThemeColor}" />
+        <Setter Property="BackgroundColor" Value="{StaticResource ThemeLightColor}" />
+    </Style>
+    <Style TargetType="Switch">
+        <Setter Property="OnColor" Value="{StaticResource ThemeSwitchLightColor}" />
+        <Setter Property="ThumbColor" Value="{StaticResource ThemeSwitchNormalColor}" />
     </Style>
     <Style TargetType="Label">
         <Setter Property="TextColor" Value="{StaticResource ThemeTextColor}" />
     </Style>
+    <Style TargetType="controls:FloatingEntry">
+        <Setter Property="TextColor" Value="{StaticResource ThemeTextColor}" />
+        <Setter Property="EntryPlaceholderColor" Value="{StaticResource ThemeLightColor}" />
+        <Setter Property="EntryBackgroundColor" Value="{StaticResource ThemeBackgroundColor}" />
+    </Style>
+    <Style TargetType="controls:FloatingLabel">
+        <Setter Property="TextColor" Value="{StaticResource ThemeTextColor}" />
+        <Setter Property="LabelBackgroundColor" Value="{StaticResource ThemeLightColor}" />
+    </Style>
 
 </ResourceDictionary>
-
-

--- a/Spacearr.Core.Xamarin/Themes/LightTheme.xaml
+++ b/Spacearr.Core.Xamarin/Themes/LightTheme.xaml
@@ -1,25 +1,54 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <ResourceDictionary xmlns="http://xamarin.com/schemas/2014/forms"
                     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                    xmlns:controls="clr-namespace:Spacearr.Core.Xamarin.Controls;assembly=Spacearr.Core.Xamarin"
                     x:Class="Spacearr.Core.Xamarin.Themes.LightTheme">
 
-    <Color x:Key="ThemeColor">#2196F3</Color>
-    <Color x:Key="ThemeTextColor">Black</Color>
+    <Color x:Key="ThemeLightColor">#ff833a</Color>
+    <Color x:Key="ThemeNormalColor">#e65100</Color>
+    <Color x:Key="ThemeDarkColor">#ac1900</Color>
+    <Color x:Key="ThemeTextColor">#000000</Color>
+    <Color x:Key="ThemeBackgroundColor">#ffffff</Color>
+    <Color x:Key="ThemeSwitchLightColor">#e65100</Color>
+    <Color x:Key="ThemeSwitchNormalColor">#ac1900</Color>
+    <Color x:Key="ErrorTextColor">#b71c1c</Color>
+    <Color x:Key="MicroChartsFreeSpaceColor">#ffffff</Color>
+    <Color x:Key="MicroChartsUsedSpaceColor">#e65100</Color>
+    <Color x:Key="ProgressBarColor">#e65100</Color>
     <Style TargetType="ContentPage">
-        <Setter Property="BackgroundColor" Value="{StaticResource ThemeColor}" />
+        <Setter Property="BackgroundColor" Value="{StaticResource ThemeDarkColor}" />
     </Style>
     <Style TargetType="NavigationPage">
-        <Setter Property="BarBackgroundColor" Value="{StaticResource ThemeColor}" />
+        <Setter Property="BarBackgroundColor" Value="{StaticResource ThemeDarkColor}" />
         <Setter Property="BarTextColor" Value="{StaticResource ThemeTextColor}" />
     </Style>
     <Style TargetType="StackLayout">
-        <Setter Property="BackgroundColor" Value="{StaticResource ThemeColor}" />
+        <Setter Property="BackgroundColor" Value="{StaticResource ThemeBackgroundColor}" />
+    </Style>
+    <Style TargetType="ListView">
+        <Setter Property="BackgroundColor" Value="{StaticResource ThemeBackgroundColor}" />
+    </Style>
+    <Style TargetType="Frame">
+        <Setter Property="BackgroundColor" Value="{StaticResource ThemeLightColor}" />
     </Style>
     <Style TargetType="Grid">
-        <Setter Property="BackgroundColor" Value="{StaticResource ThemeColor}" />
+        <Setter Property="BackgroundColor" Value="{StaticResource ThemeLightColor}" />
+    </Style>
+    <Style TargetType="Switch">
+        <Setter Property="OnColor" Value="{StaticResource ThemeSwitchLightColor}" />
+        <Setter Property="ThumbColor" Value="{StaticResource ThemeSwitchNormalColor}" />
     </Style>
     <Style TargetType="Label">
         <Setter Property="TextColor" Value="{StaticResource ThemeTextColor}" />
+    </Style>
+    <Style TargetType="controls:FloatingEntry">
+        <Setter Property="TextColor" Value="{StaticResource ThemeTextColor}" />
+        <Setter Property="EntryPlaceholderColor" Value="{StaticResource ThemeLightColor}" />
+        <Setter Property="EntryBackgroundColor" Value="{StaticResource ThemeBackgroundColor}" />
+    </Style>
+    <Style TargetType="controls:FloatingLabel">
+        <Setter Property="TextColor" Value="{StaticResource ThemeTextColor}" />
+        <Setter Property="LabelBackgroundColor" Value="{StaticResource ThemeLightColor}" />
     </Style>
 
 </ResourceDictionary>

--- a/Spacearr.Core.Xamarin/Views/ComputerDriveDetailPage.xaml
+++ b/Spacearr.Core.Xamarin/Views/ComputerDriveDetailPage.xaml
@@ -1,25 +1,38 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:microcharts="clr-namespace:Microcharts.Forms;assembly=Microcharts.Forms" 
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:microcharts="clr-namespace:Microcharts.Forms;assembly=Microcharts.Forms"
              xmlns:viewModels="clr-namespace:Spacearr.Core.Xamarin.ViewModels;assembly=Spacearr.Core.Xamarin"
+             xmlns:controls="clr-namespace:Spacearr.Core.Xamarin.Controls;assembly=Spacearr.Core.Xamarin"
              mc:Ignorable="d"
              x:Class="Spacearr.Core.Xamarin.Views.ComputerDriveDetailPage"
              Title="{Binding Title}" x:DataType="viewModels:ComputerDriveDetailViewModel">
 
     <ScrollView>
-        <StackLayout Spacing="20" Padding="15">
-            <microcharts:ChartView x:Name="chartView" HeightRequest="200" VerticalOptions="FillAndExpand" />
-            <Label Text="Name:" FontSize="Medium" />
-            <Label Text="{Binding ComputerDriveModel.Name}" d:Text="Computer drive name label" FontSize="Small" />
-            <Label Text="Volume Label:" FontSize="Medium" />
-            <Label Text="{Binding ComputerDriveModel.VolumeLabel}" d:Text="Computer drive volume label" FontSize="Small" />
-            <Label Text="Drive Type:" FontSize="Medium" />
-            <Label Text="{Binding ComputerDriveModel.DriveType}" d:Text="Computer drive type label" FontSize="Small" />
-            <Label Text="Is Ready:" FontSize="Medium" />
-            <CheckBox IsChecked="{Binding ComputerDriveModel.IsReady}" IsEnabled="False" />
+        <StackLayout>
+            <Frame Margin="5" HasShadow="True" CornerRadius="2">
+                <StackLayout>
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+                        <Grid Grid.Row="0">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+                            <microcharts:ChartView Grid.Row="0"  x:Name="Chart" HeightRequest="200" VerticalOptions="FillAndExpand" />
+                            <controls:FloatingLabel Grid.Row="1" LabelTopText="Name" LabelBottomText="{Binding ComputerDriveModel.Name}"/>
+                            <controls:FloatingLabel Grid.Row="2" LabelTopText="Volume Label" LabelBottomText="{Binding ComputerDriveModel.VolumeLabel}"/>
+                            <controls:FloatingLabel Grid.Row="3" LabelTopText="Drive Type" LabelBottomText="{Binding ComputerDriveModel.DriveType}"/>
+                        </Grid>
+                    </Grid>
+                </StackLayout>
+            </Frame>
         </StackLayout>
     </ScrollView>
 

--- a/Spacearr.Core.Xamarin/Views/ComputerDriveDetailPage.xaml.cs
+++ b/Spacearr.Core.Xamarin/Views/ComputerDriveDetailPage.xaml.cs
@@ -23,26 +23,32 @@ namespace Spacearr.Core.Xamarin.Views
         protected override void OnAppearing()
         {
             base.OnAppearing();
-            
+
+            var themeTextColor = (Color)Application.Current.Resources["ThemeTextColor"];
+            var themeLightColor = (Color)Application.Current.Resources["ThemeLightColor"];
+            var microChartsFreeSpaceColor = (Color)Application.Current.Resources["MicroChartsFreeSpaceColor"];
+            var microChartsUsedSpaceColor = (Color)Application.Current.Resources["MicroChartsUsedSpaceColor"];
+
             var entries = new[]
             {
                 new ChartEntry(_viewModel.ComputerDriveModel.TotalUsedSpace)
                 {
                     Label = "Used Space",
                     ValueLabel = $"{_viewModel.ComputerDriveModel.TotalUsedSpaceString}",
-                    Color = SKColor.Parse("#68B9C0")
+                    Color = SKColor.Parse(microChartsUsedSpaceColor.ToHex()),
+                    TextColor = SKColor.Parse(themeTextColor.ToHex())
                 },
                 new ChartEntry(_viewModel.ComputerDriveModel.TotalFreeSpace)
                 {
                     Label = "Total Free Space",
                     ValueLabel = $"{_viewModel.ComputerDriveModel.TotalFreeSpaceString}",
-                    Color = SKColor.Parse("#90D585"),
+                    Color = SKColor.Parse(microChartsFreeSpaceColor.ToHex()),
+                    TextColor = SKColor.Parse(themeTextColor.ToHex())
                 }
             };
+            var chart = new PieChart { Entries = entries, BackgroundColor = SKColor.Parse(themeLightColor.ToHex()) };
 
-            var chart = new PieChart { Entries = entries };
-
-            this.chartView.Chart = chart;
+            Chart.Chart = chart;
         }
     }
 }

--- a/Spacearr.Core.Xamarin/Views/ComputerDrivesPage.xaml
+++ b/Spacearr.Core.Xamarin/Views/ComputerDrivesPage.xaml
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
              xmlns:models="clr-namespace:Spacearr.Common.Models;assembly=Spacearr.Common"
              xmlns:viewModels="clr-namespace:Spacearr.Core.Xamarin.ViewModels;assembly=Spacearr.Core.Xamarin"
              mc:Ignorable="d"
@@ -29,18 +29,27 @@
             <ListView.ItemTemplate>
                 <DataTemplate x:DataType="models:ComputerDriveModel">
                     <ViewCell>
-                        <StackLayout Padding="10">
-                            <Label Text="{Binding Name}" 
-                                d:Text="{Binding Name}"
-                                LineBreakMode="NoWrap" 
-                                Style="{DynamicResource ListItemTextStyle}" 
-                                FontSize="16" />
-                            <ProgressBar Progress="{Binding ProgressBarValue}" />
-                        </StackLayout>
+                        <Frame Margin="5" HasShadow="True" CornerRadius="2">
+                            <StackLayout>
+                                <Grid>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="*"/>
+                                    </Grid.RowDefinitions>
+                                    <Grid>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                        </Grid.RowDefinitions>
+                                        <Label FontAttributes="Bold" Grid.Row="0" Text="{Binding Name}" />
+                                        <ProgressBar Grid.Row="1" Progress="{Binding ProgressBarValue}" ProgressColor="{DynamicResource ProgressBarColor}" />
+                                    </Grid>
+                                </Grid>
+                            </StackLayout>
+                        </Frame>
                     </ViewCell>
                 </DataTemplate>
             </ListView.ItemTemplate>
         </ListView>
     </StackLayout>
-    
+
 </ContentPage>

--- a/Spacearr.Core.Xamarin/Views/HomePage.xaml
+++ b/Spacearr.Core.Xamarin/Views/HomePage.xaml
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
              mc:Ignorable="d"
              x:Class="Spacearr.Core.Xamarin.Views.HomePage"
              Title="{Binding Title}"
-             BackgroundColor="{DynamicResource ThemeColor}">
+             BackgroundColor="{DynamicResource ThemeBackgroundColor}">
 
     <Label Text="Welcome" FontSize="Large" HorizontalOptions="CenterAndExpand" VerticalOptions="CenterAndExpand" />
 

--- a/Spacearr.Core.Xamarin/Views/LogDetailPage.xaml
+++ b/Spacearr.Core.Xamarin/Views/LogDetailPage.xaml
@@ -1,25 +1,40 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:controls="clr-namespace:Spacearr.Core.Xamarin.Controls;assembly=Spacearr.Core.Xamarin"
              xmlns:viewModels="clr-namespace:Spacearr.Core.Xamarin.ViewModels;assembly=Spacearr.Core.Xamarin"
              mc:Ignorable="d"
              x:Class="Spacearr.Core.Xamarin.Views.LogDetailPage"
-             Title="{Binding Title}" x:DataType="viewModels:LogDetailViewModel">
+             Title="{Binding Title}"
+             x:DataType="viewModels:LogDetailViewModel">
 
     <ScrollView>
-        <StackLayout Spacing="20" Padding="15">
-            <Label Text="Id:" FontSize="Medium" />
-            <Label Text="{Binding Log.Id}" d:Text="Id 1 label" FontSize="Small" />
-            <Label Text="Log Message:" FontSize="Medium" />
-            <Label Text="{Binding Log.LogMessage}" d:Text="Log message label" FontSize="Small" />
-            <Label Text="Log Stack Trace:" FontSize="Medium" />
-            <Label Text="{Binding Log.LogStackTrace}" d:Text="Log stack trace label" FontSize="Small" />
-            <Label Text="Log Type:" FontSize="Medium" />
-            <Label Text="{Binding Log.LogType}" d:Text="log type label" FontSize="Small" />
-            <Label Text="Log Date:" FontSize="Medium" />
-            <Label Text="{Binding Log.LogDate}" d:Text="log date label" FontSize="Small" />
+        <StackLayout>
+            <Frame Margin="5" HasShadow="True" CornerRadius="2">
+                <StackLayout>
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+                        <Grid Grid.Row="0">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+                            <controls:FloatingLabel Grid.Row="0" LabelTopText="Id" LabelBottomText="{Binding Log.Id}"/>
+                            <controls:FloatingLabel Grid.Row="1" LabelTopText="Log Message" LabelBottomText="{Binding Log.LogMessage}"/>
+                            <controls:FloatingLabel Grid.Row="2" LabelTopText="Stack Trace" LabelBottomText="{Binding Log.LogStackTrace}"/>
+                            <controls:FloatingLabel Grid.Row="3" LabelTopText="Log Type" LabelBottomText="{Binding Log.LogType}"/>
+                            <controls:FloatingLabel Grid.Row="4" LabelTopText="Log Date" LabelBottomText="{Binding Log.LogDate}"/>
+                        </Grid>
+                    </Grid>
+                </StackLayout>
+            </Frame>
         </StackLayout>
     </ScrollView>
 

--- a/Spacearr.Core.Xamarin/Views/LogsPage.xaml
+++ b/Spacearr.Core.Xamarin/Views/LogsPage.xaml
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
              xmlns:models="clr-namespace:Spacearr.Common.Models;assembly=Spacearr.Common"
              xmlns:viewModels="clr-namespace:Spacearr.Core.Xamarin.ViewModels;assembly=Spacearr.Core.Xamarin"
              mc:Ignorable="d"
@@ -19,27 +19,48 @@
                 IsPullToRefreshEnabled="true"
                 IsRefreshing="{Binding IsBusy, Mode=OneWay}"
                 CachingStrategy="RecycleElement"
-                ItemSelected="OnLogSelected" x:DataType="viewModels:LogsViewModel">
+                ItemSelected="OnLogSelected"
+                x:DataType="viewModels:LogsViewModel">
             <d:ListView.ItemsSource>
                 <x:Array Type="{x:Type models:LogModel}">
-                    <models:LogModel LogMessage = "Log message 1" />
-                    <models:LogModel LogMessage = "Log message 2" />
+                    <models:LogModel LogMessage = "Log message 1" LogDate = "2020/01/01" />
+                    <models:LogModel LogMessage = "Log message 2" LogDate = "2020/01/02" />
                 </x:Array>
             </d:ListView.ItemsSource>
             <ListView.ItemTemplate>
                 <DataTemplate x:DataType="models:LogModel">
                     <ViewCell>
-                        <StackLayout Padding="10">
-                            <Label Text="{Binding LogMessage}" 
-                                d:Text="{Binding LogMessage}"
-                                LineBreakMode="NoWrap" 
-                                Style="{DynamicResource ListItemTextStyle}" 
-                                FontSize="16" />
-                        </StackLayout>
+                        <Frame Margin="5" HasShadow="True" CornerRadius="2">
+                            <StackLayout>
+                                <Grid>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="*"/>
+                                    </Grid.RowDefinitions>
+                                    <Grid Grid.Row="0">
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                        </Grid.RowDefinitions>
+                                        <Label FontAttributes="Bold" Grid.Row="0" Text="{Binding LogMessage}" />
+                                        <Grid Grid.Row="1">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="Auto" />
+                                                <ColumnDefinition Width="Auto" />
+                                            </Grid.ColumnDefinitions>
+                                            <Grid.RowDefinitions>
+                                                <RowDefinition Height="Auto"/>
+                                            </Grid.RowDefinitions>
+                                            <Label Grid.Row="0" Grid.Column="0" Text="Log date:"/>
+                                            <Label Grid.Row="0" Grid.Column="1"  Text="{Binding LogDate}"/>
+                                        </Grid>
+                                    </Grid>
+                                </Grid>
+                            </StackLayout>
+                        </Frame>
                     </ViewCell>
                 </DataTemplate>
             </ListView.ItemTemplate>
         </ListView>
     </StackLayout>
-    
+
 </ContentPage>

--- a/Spacearr.Core.Xamarin/Views/MainPage.xaml
+++ b/Spacearr.Core.Xamarin/Views/MainPage.xaml
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <MasterDetailPage xmlns="http://xamarin.com/schemas/2014/forms"
-            xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-            xmlns:d="http://xamarin.com/schemas/2014/forms/design"
-            xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-            mc:Ignorable="d"
-            xmlns:views="clr-namespace:Spacearr.Core.Xamarin.Views"
-            x:Class="Spacearr.Core.Xamarin.Views.MainPage">
+                  xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                  xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+                  xmlns:views="clr-namespace:Spacearr.Core.Xamarin.Views"
+                  mc:Ignorable="d"
+                  x:Class="Spacearr.Core.Xamarin.Views.MainPage">
 
     <MasterDetailPage.Detail>
         <NavigationPage>
@@ -14,5 +14,5 @@
             </x:Arguments>
         </NavigationPage>
     </MasterDetailPage.Detail>
-    
+
 </MasterDetailPage>

--- a/Spacearr.Core.Xamarin/Views/MenuPage.xaml
+++ b/Spacearr.Core.Xamarin/Views/MenuPage.xaml
@@ -1,42 +1,44 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
              xmlns:models="clr-namespace:Spacearr.Core.Xamarin.Models;assembly=Spacearr.Core.Xamarin"
              mc:Ignorable="d"
              x:Class="Spacearr.Core.Xamarin.Views.MenuPage"
              Title="Menu">
-             
-    <StackLayout VerticalOptions="FillAndExpand">
-        <ListView x:Name="ListViewMenu" HasUnevenRows="True" SeparatorVisibility="None">
-            <d:ListView.ItemsSource>
-                <x:Array Type="{x:Type models:HomeMenuItemModel}">
-                    <models:HomeMenuItemModel Id = "1" Title="Title 1"/>
-                    <models:HomeMenuItemModel Id = "2" Title="Title 2"/>
-                </x:Array>
-            </d:ListView.ItemsSource>
-            <ListView.ItemTemplate>
-                <DataTemplate>
-                    <ViewCell x:DataType="models:HomeMenuItemModel">
-                        <Grid Padding="10">
-                            <Label Text="{Binding Title}" d:Text="{Binding Title}" FontSize="20"/>
-                        </Grid>
-                    </ViewCell>
-                </DataTemplate>
-            </ListView.ItemTemplate>
-        </ListView>
-        <Grid VerticalOptions="Center">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-            <Grid.RowDefinitions>
-                <RowDefinition Height="40"/>
-            </Grid.RowDefinitions>
-            <Label VerticalTextAlignment="Center" Grid.Row="0" Grid.Column="0" x:Name="DarkThemeText"></Label>
-            <Switch Grid.Row="0" Grid.Column="1" VerticalOptions="Center" x:Name="DarkTheme" Toggled="OnToggled"/>
-        </Grid>
-    </StackLayout>
+
+    <Frame BackgroundColor="{DynamicResource ThemeNormalColor}" BorderColor="{DynamicResource ThemeDarkColor}" HasShadow="True" CornerRadius="0">
+        <StackLayout VerticalOptions="FillAndExpand" BackgroundColor="{DynamicResource ThemeNormalColor}">
+            <ListView x:Name="ListViewMenu" HasUnevenRows="True" BackgroundColor="{DynamicResource ThemeNormalColor}">
+                <d:ListView.ItemsSource>
+                    <x:Array Type="{x:Type models:HomeMenuItemModel}">
+                        <models:HomeMenuItemModel Id = "1" Title="Title 1"/>
+                        <models:HomeMenuItemModel Id = "2" Title="Title 2"/>
+                    </x:Array>
+                </d:ListView.ItemsSource>
+                <ListView.ItemTemplate>
+                    <DataTemplate>
+                        <ViewCell x:DataType="models:HomeMenuItemModel">
+                            <Grid Padding="10" BackgroundColor="{DynamicResource ThemeNormalColor}">
+                                <Label Text="{Binding Title}" d:Text="{Binding Title}" FontSize="20"/>
+                            </Grid>
+                        </ViewCell>
+                    </DataTemplate>
+                </ListView.ItemTemplate>
+            </ListView>
+            <Grid Padding="10" BackgroundColor="{DynamicResource ThemeNormalColor}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="40"/>
+                </Grid.RowDefinitions>
+                <Label VerticalTextAlignment="Center" Grid.Row="0" Grid.Column="0" x:Name="DarkThemeText"></Label>
+                <Switch Grid.Row="0" Grid.Column="1" VerticalOptions="Center" x:Name="DarkTheme" Toggled="OnToggled"/>
+            </Grid>
+        </StackLayout>
+    </Frame>
 
 </ContentPage>

--- a/Spacearr.Core.Xamarin/Views/NewSettingPage.xaml
+++ b/Spacearr.Core.Xamarin/Views/NewSettingPage.xaml
@@ -1,13 +1,14 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:controls="clr-namespace:Spacearr.Core.Xamarin.Controls;assembly=Spacearr.Core.Xamarin"
              xmlns:viewModels="clr-namespace:Spacearr.Core.Xamarin.ViewModels;assembly=Spacearr.Core.Xamarin"
              mc:Ignorable="d"
              x:Class="Spacearr.Core.Xamarin.Views.NewSettingPage"
              Title="{Binding Title}" x:DataType="viewModels:NewSettingDetailViewModel">
-    
+
     <ContentPage.ToolbarItems>
         <ToolbarItem Text="Cancel" Command="{Binding CancelCommand}" />
         <ToolbarItem Text="Save" Command="{Binding SaveCommand}" />
@@ -16,23 +17,27 @@
     <ContentPage.Content>
         <ScrollView>
             <StackLayout Spacing="20" Padding="15">
-                <Label Text="Computer Name:" FontSize="Medium" />
-                <Entry Text="{Binding SettingModel.ComputerName}" d:Text="Computer name" FontSize="Small" />
-                <Label x:Name="SettingModel_ComputerNameError" IsVisible="False" TextColor="Red" />
-                <Label Text="Pusher App Id:" FontSize="Medium" />
-                <Entry Text="{Binding SettingModel.PusherAppId}" d:Text="Pusher app id" FontSize="Small" />
-                <Label x:Name="SettingModel_PusherAppIdError" IsVisible="False" TextColor="Red" />
-                <Label Text="Pusher Key:" FontSize="Medium" />
-                <Entry Text="{Binding SettingModel.PusherKey}" d:Text="Pusher key" FontSize="Small" />
-                <Label x:Name="SettingModel_PusherKeyError" IsVisible="False" TextColor="Red" />
-                <Label Text="Pusher Secret:" FontSize="Medium" />
-                <Entry Text="{Binding SettingModel.PusherSecret}" d:Text="Pusher secret" FontSize="Small" />
-                <Label x:Name="SettingModel_PusherSecretError" IsVisible="False" TextColor="Red" />
-                <Label Text="Pusher Cluster:" FontSize="Medium" />
-                <Entry Text="{Binding SettingModel.PusherCluster}" d:Text="Pusher cluster" FontSize="Small" />
-                <Label x:Name="SettingModel_PusherClusterError" IsVisible="False" TextColor="Red" />
-                <Label Text="Is Default:" FontSize="Medium" />
-                <CheckBox IsChecked="{Binding SettingModel.IsDefault}" />
+                <controls:FloatingEntry Text="{Binding SettingModel.ComputerName}" Placeholder="Computer Name"/>
+                <Label x:Name="SettingModel_ComputerNameError" IsVisible="False" TextColor="{DynamicResource ErrorTextColor}" />
+                <controls:FloatingEntry Text="{Binding SettingModel.PusherAppId}" Placeholder="Pusher App Id"/>
+                <Label x:Name="SettingModel_PusherAppIdError" IsVisible="False" TextColor="{DynamicResource ErrorTextColor}" />
+                <controls:FloatingEntry Text="{Binding SettingModel.PusherKey}" Placeholder="Pusher Key"/>
+                <Label x:Name="SettingModel_PusherKeyError" IsVisible="False" TextColor="{DynamicResource ErrorTextColor}" />
+                <controls:FloatingEntry Text="{Binding SettingModel.PusherSecret}" Placeholder="Pusher Secret"/>
+                <Label x:Name="SettingModel_PusherSecretError" IsVisible="False" TextColor="{DynamicResource ErrorTextColor}" />
+                <controls:FloatingEntry Text="{Binding SettingModel.PusherCluster}" Placeholder="Pusher Cluster"/>
+                <Label x:Name="SettingModel_PusherClusterError" IsVisible="False" TextColor="{DynamicResource ErrorTextColor}" />
+                <Grid Padding="10" BackgroundColor="{DynamicResource ThemeBackgroundColor}">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="40"/>
+                    </Grid.RowDefinitions>
+                    <Label VerticalTextAlignment="Center" Grid.Row="0" Grid.Column="0" Text="Is Default:" FontSize="Medium"></Label>
+                    <Switch Grid.Row="0" Grid.Column="1" VerticalOptions="Center" IsToggled="{Binding SettingModel.IsDefault}"/>
+                </Grid>
             </StackLayout>
         </ScrollView>
     </ContentPage.Content>

--- a/Spacearr.Core.Xamarin/Views/NotificationDetailPage.xaml
+++ b/Spacearr.Core.Xamarin/Views/NotificationDetailPage.xaml
@@ -1,19 +1,34 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:controls="clr-namespace:Spacearr.Core.Xamarin.Controls;assembly=Spacearr.Core.Xamarin"
              xmlns:viewModels="clr-namespace:Spacearr.Core.Xamarin.ViewModels;assembly=Spacearr.Core.Xamarin"
              mc:Ignorable="d"
              x:Class="Spacearr.Core.Xamarin.Views.NotificationDetailPage"
              Title="{Binding Title}" x:DataType="viewModels:NotificationDetailViewModel">
 
     <ScrollView>
-        <StackLayout Spacing="20" Padding="15">
-            <Label Text="Title:" FontSize="Medium" />
-            <Label Text="{Binding Notification.Title}" d:Text="Title label" FontSize="Small" />
-            <Label Text="Message:" FontSize="Medium" />
-            <Label Text="{Binding Notification.Message}" d:Text="Message label" FontSize="Small" />
+        <StackLayout>
+            <Frame Margin="5" HasShadow="True" CornerRadius="2">
+                <StackLayout>
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+                        <Grid Grid.Row="0">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+                            <controls:FloatingLabel Grid.Row="0" LabelTopText="{Binding Notification.Title}" LabelBottomText="{Binding Notification.Message}"/>
+                        </Grid>
+                    </Grid>
+                </StackLayout>
+            </Frame>
         </StackLayout>
     </ScrollView>
 

--- a/Spacearr.Core.Xamarin/Views/SettingDetailPage.xaml
+++ b/Spacearr.Core.Xamarin/Views/SettingDetailPage.xaml
@@ -1,8 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:controls="clr-namespace:Spacearr.Core.Xamarin.Controls;assembly=Spacearr.Core.Xamarin"
              xmlns:viewModels="clr-namespace:Spacearr.Core.Xamarin.ViewModels;assembly=Spacearr.Core.Xamarin"
              mc:Ignorable="d"
              x:Class="Spacearr.Core.Xamarin.Views.SettingDetailPage"
@@ -16,23 +17,27 @@
     <ContentPage.Content>
         <ScrollView>
             <StackLayout Spacing="20" Padding="15">
-                <Label Text="Computer Name:" FontSize="Medium" />
-                <Entry Text="{Binding SettingModel.ComputerName}" d:Text="Computer name" FontSize="Small" />
-                <Label x:Name="SettingModel_ComputerNameError" IsVisible="False" TextColor="Red" />
-                <Label Text="Pusher App Id:" FontSize="Medium" />
-                <Entry Text="{Binding SettingModel.PusherAppId}" d:Text="Pusher app id" FontSize="Small" />
-                <Label x:Name="SettingModel_PusherAppIdError" IsVisible="False" TextColor="Red" />
-                <Label Text="Pusher Key:" FontSize="Medium" />
-                <Entry Text="{Binding SettingModel.PusherKey}" d:Text="Pusher key" FontSize="Small" />
-                <Label x:Name="SettingModel_PusherKeyError" IsVisible="False" TextColor="Red" />
-                <Label Text="Pusher Secret:" FontSize="Medium" />
-                <Entry Text="{Binding SettingModel.PusherSecret}" d:Text="Pusher secret" FontSize="Small" />
-                <Label x:Name="SettingModel_PusherSecretError" IsVisible="False" TextColor="Red" />
-                <Label Text="Pusher Cluster:" FontSize="Medium" />
-                <Entry Text="{Binding SettingModel.PusherCluster}" d:Text="Pusher cluster" FontSize="Small" />
-                <Label x:Name="SettingModel_PusherClusterError" IsVisible="False" TextColor="Red" />
-                <Label Text="Is Default:" FontSize="Medium" />
-                <CheckBox IsChecked="{Binding SettingModel.IsDefault}" />
+                <controls:FloatingEntry Text="{Binding SettingModel.ComputerName}" Placeholder="Computer Name"/>
+                <Label x:Name="SettingModel_ComputerNameError" IsVisible="False" TextColor="{DynamicResource ErrorTextColor}" />
+                <controls:FloatingEntry Text="{Binding SettingModel.PusherAppId}" Placeholder="Pusher App Id"/>
+                <Label x:Name="SettingModel_PusherAppIdError" IsVisible="False" TextColor="{DynamicResource ErrorTextColor}" />
+                <controls:FloatingEntry Text="{Binding SettingModel.PusherKey}" Placeholder="Pusher Key"/>
+                <Label x:Name="SettingModel_PusherKeyError" IsVisible="False" TextColor="{DynamicResource ErrorTextColor}" />
+                <controls:FloatingEntry Text="{Binding SettingModel.PusherSecret}" Placeholder="Pusher Secret"/>
+                <Label x:Name="SettingModel_PusherSecretError" IsVisible="False" TextColor="{DynamicResource ErrorTextColor}" />
+                <controls:FloatingEntry Text="{Binding SettingModel.PusherCluster}" Placeholder="Pusher Cluster"/>
+                <Label x:Name="SettingModel_PusherClusterError" IsVisible="False" TextColor="{DynamicResource ErrorTextColor}" />
+                <Grid Padding="10" BackgroundColor="{DynamicResource ThemeBackgroundColor}">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="40"/>
+                    </Grid.RowDefinitions>
+                    <Label VerticalTextAlignment="Center" Grid.Row="0" Grid.Column="0" Text="Is Default:" FontSize="Medium"></Label>
+                    <Switch Grid.Row="0" Grid.Column="1" VerticalOptions="Center" IsToggled="{Binding SettingModel.IsDefault}"/>
+                </Grid>
             </StackLayout>
         </ScrollView>
     </ContentPage.Content>

--- a/Spacearr.Core.Xamarin/Views/SettingsPage.xaml
+++ b/Spacearr.Core.Xamarin/Views/SettingsPage.xaml
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
              xmlns:models="clr-namespace:Spacearr.Common.Models;assembly=Spacearr.Common"
              xmlns:viewModels="clr-namespace:Spacearr.Core.Xamarin.ViewModels;assembly=Spacearr.Core.Xamarin"
              mc:Ignorable="d"
@@ -15,35 +15,56 @@
     </ContentPage.ToolbarItems>
 
     <StackLayout>
-        <ListView x:Name="SettingsListView"
-                  ItemsSource="{Binding Settings}"
-                  VerticalOptions="FillAndExpand"
-                  HasUnevenRows="true"
-                  RefreshCommand="{Binding LoadItemsCommand}"
-                  IsPullToRefreshEnabled="true"
-                  IsRefreshing="{Binding IsBusy, Mode=OneWay}"
-                  CachingStrategy="RecycleElement"
-                  ItemSelected="OnItemSelected" x:DataType="viewModels:SettingsViewModel">
+        <ListView x:Name="SettingsListView" 
+                ItemsSource="{Binding Settings}"
+                VerticalOptions="FillAndExpand"
+                HasUnevenRows="true"
+                RefreshCommand="{Binding LoadItemsCommand}"
+                IsPullToRefreshEnabled="true"
+                IsRefreshing="{Binding IsBusy, Mode=OneWay}"
+                CachingStrategy="RecycleElement"
+                ItemSelected="OnItemSelected"
+                x:DataType="viewModels:SettingsViewModel">
             <d:ListView.ItemsSource>
                 <x:Array Type="{x:Type models:SettingModel}">
-                    <models:SettingModel ComputerName = "Computer name 1" />
-                    <models:SettingModel ComputerName = "Computer name 2" />
+                    <models:SettingModel ComputerName = "Computer name 1" UpdatedDate = "2020/01/01" />
+                    <models:SettingModel ComputerName = "Computer name 2" UpdatedDate = "2020/01/02" />
                 </x:Array>
             </d:ListView.ItemsSource>
             <ListView.ItemTemplate>
                 <DataTemplate x:DataType="models:SettingModel">
                     <ViewCell>
-                        <StackLayout Padding="10">
-                            <Label Text="{Binding ComputerName}" 
-                                d:Text="{Binding ComputerName}"
-                                LineBreakMode="NoWrap" 
-                                Style="{DynamicResource ListItemTextStyle}" 
-                                FontSize="16" />
-                        </StackLayout>
+                        <Frame Margin="5" HasShadow="True" CornerRadius="2">
+                            <StackLayout>
+                                <Grid>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="*"/>
+                                    </Grid.RowDefinitions>
+                                    <Grid Grid.Row="0">
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                        </Grid.RowDefinitions>
+                                        <Label FontAttributes="Bold" Grid.Row="0" Text="{Binding ComputerName}" />
+                                        <Grid Grid.Row="1">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="Auto" />
+                                                <ColumnDefinition Width="Auto" />
+                                            </Grid.ColumnDefinitions>
+                                            <Grid.RowDefinitions>
+                                                <RowDefinition Height="Auto"/>
+                                            </Grid.RowDefinitions>
+                                            <Label Grid.Row="0" Grid.Column="0" Text="Updated on:"/>
+                                            <Label Grid.Row="0" Grid.Column="1"  Text="{Binding UpdatedDate}"/>
+                                        </Grid>
+                                    </Grid>
+                                </Grid>
+                            </StackLayout>
+                        </Frame>
                     </ViewCell>
                 </DataTemplate>
             </ListView.ItemTemplate>
         </ListView>
     </StackLayout>
-    
+
 </ContentPage>


### PR DESCRIPTION
Add FloatingEntry and use that when displaying or setting or when adding a setting.
Use a cards design on information pages that use a list Rename theme variables Change "Is Defult" tick box to switch.
Fix space and format in Views.
Neaten FloatingEntry.
Fixed FloatingEntry not showing labels when coming into the screen with values already.
Change switch colours for light theme.
NotificationDetailPage, LogDetailPage and ComputerDriveDetailPage uses cards now.
Fix colour of chart Change ErrorTextColor to use Hex Change Frame CornerRadius to 2 from 5 Set progress bar colour.
Set status bar color to ThemeDarkColor for Android.
Change EntryPlaceholderColor.
ComputerDriveDetailPage disable switch Add FloatingLabel Use FloatingLabel on LogDetailPage.
ComputerDriveDetailPage changed to use FloatingLabel to display information.
LogDetailPage changed to use one card NotificationDetailPage change to use FloatingLabel

fixes GH-10
fixes GH-11